### PR TITLE
Make ipynbcompress compatible with ipynb > 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 
 python:
-  - "3.4"
-  - "2.7"
+  - "3.8"
+  # - "2.7"
 
 # install link to package
 install: 

--- a/ipynbcompress/ipynbcompress.py
+++ b/ipynbcompress/ipynbcompress.py
@@ -3,7 +3,7 @@ from base64 import b64decode, b64encode
 from PIL import Image
 from io import BytesIO
 from os import stat
-from IPython.nbformat import read, write
+from nbformat import read, write
 
 
 def compress(filename, output_filename=None, img_width=2048, img_format='png'):
@@ -53,6 +53,7 @@ def compress(filename, output_filename=None, img_width=2048, img_format='png'):
                     new_size = [int(s*factor+0.5) for s in img.size]
                     img = img.resize(new_size)
                 out = BytesIO()
+                img=img.convert("RGB")
                 img.save(out, img_format)
                 out.seek(0)
                 mime = 'image/' + img_format

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 wheel>=0.22
 setuptools-git
 tox
+nbformat
 
 # equivalent to ./setup develop
 -e .

--- a/test/test_compress.py
+++ b/test/test_compress.py
@@ -3,7 +3,7 @@ Tests for `ipynbcompress`.
 """
 import pytest
 from ipynbcompress import *
-from IPython.nbformat import validate, read, NO_CONVERT
+from nbformat import validate, read, NO_CONVERT
 from py import path
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py27, py34
+; envlist = py27, py34
+envlist = py38
 
 [testenv]
 setenv =


### PR DESCRIPTION
Fixed issue #5 bug which was caused by [ipynb deprecated subpackages](https://ipython.readthedocs.io/en/stable/whatsnew/version4.html#ipython-4-0)

And fixed a weird bug OSError: cannot write mode RGBA as JPEG. during test.